### PR TITLE
Fixed decode issue

### DIFF
--- a/src/main/python/crptr/corrupt_values/corrupt_abbreviated_name_forms.py
+++ b/src/main/python/crptr/corrupt_values/corrupt_abbreviated_name_forms.py
@@ -38,9 +38,8 @@ class CorruptAbbreviatedNameForms(CorruptValue):
        string by randomly selecting an edit operation and position in the
        string where to apply this edit.
     """
-    in_str = in_str.decode("UTF-8")
 
     if (len(in_str) == 0) or (len(in_str) < self.num_of_char):  # Empty string, no modification possible
       return in_str
     new_str = in_str[:self.num_of_char]
-    return str(new_str.encode("UTF-8", errors='strict'))
+    return new_str

--- a/src/main/python/crptr/corrupt_values/corrupt_unknown_character.py
+++ b/src/main/python/crptr/corrupt_values/corrupt_unknown_character.py
@@ -36,10 +36,10 @@ class CorruptUnknownCharacter(CorruptValue):
        string by randomly selecting an edit operation and position in the
        string where to apply this edit.
     """
-    temp = in_str
-    in_str = in_str.decode("UTF-8")
+
     if (len(in_str) == 0):  # Empty string, no modification possible
       return in_str
+    
     mod_pos = self.position_function(in_str)
     new_str = in_str[:mod_pos] + self.unknown_char + in_str[mod_pos + 1:]
-    return str(new_str.encode("UTF-8", errors='strict'))
+    return new_str

--- a/src/main/python/crptr/corrupt_values/corrupt_value_ocr.py
+++ b/src/main/python/crptr/corrupt_values/corrupt_value_ocr.py
@@ -130,8 +130,6 @@ class CorruptValueOCR(CorruptValue):
        If there are several OCR variations then one will be randomly chosen.
     """
 
-    in_str = in_str.decode("UTF-8")
-
     if (len(in_str) == 0):  # Empty string, no modification possible
       return in_str
 
@@ -176,4 +174,4 @@ class CorruptValueOCR(CorruptValue):
       else:
         try_num += 1
 
-    return str(mod_str.encode("UTF-8", errors='strict'))
+    return mod_str


### PR DESCRIPTION
Fixed the str decode issue and a number of accompanying issues introduced during the porting process from python 2 to python 3 (due to changes in how Strings and Byte formats are handled). Example corruptors now fully functional. Closes #19 